### PR TITLE
fix: Use new selector to get channel URL for VODs

### DIFF
--- a/src/current_page.js
+++ b/src/current_page.js
@@ -28,7 +28,7 @@ const getStreamFromVOD = _ => {
     return streamFromUrl(window.location.href)
   return new Promise(r => {
     const interval = setInterval(_ => {
-      const header = document.querySelector('.channel-info-content a[data-a-target="watch-mode-to-home"]')
+      const header = document.querySelector('a[data-test-selector="ChannelLink"]')
       if (header && header.href) {
         clearInterval(interval)
         r(streamFromUrl(header.href))


### PR DESCRIPTION
## Context 
The current selector to get the VOD's channel URL is no longer valid. It causes `getStreamFromVOD` to hang and prevent the toggle button from being injected. 

Reported here #55 

## Changes
- Use a new selector, there are multiple options but I chose one that looked the least machine generated.