### PR TITLE
feat: Join chat room when/if necessary

### DIFF
--- a/src/chat_room.js
+++ b/src/chat_room.js
@@ -1,22 +1,15 @@
-const openAndCloseNativeChatContainer = () => {
-  chatCollapser = document.querySelector('[data-a-target="right-column__toggle-collapse-btn"]')
-  chatCollapser.click()
-  setTimeout(function() {
-    chatCollapser.click()
-  }, 500);
-}
+const { isRightColumnClosed, openAndCloseRightColumn } = require('./current_page')
 
 const joinChatRoom = () => {
   // TODO find better way to join chat room, we should be able to
   // hook directly into Twitch's callback
-  openAndCloseNativeChatContainer()
+  openAndCloseRightColumn()
 }
 
 const isInChatRoom = () => {
   // TODO find better way to check, we could already be in the chat room 
   // even though the native chat is closed
-  rightColumnCollapsed = document.querySelector('.right-column--collapsed')
-  return !rightColumnCollapsed
+  return !isRightColumnClosed()
 }
 
 module.exports = {

--- a/src/chat_room.js
+++ b/src/chat_room.js
@@ -1,0 +1,25 @@
+const openAndCloseNativeChatContainer = () => {
+  chatCollapser = document.querySelector('[data-a-target="right-column__toggle-collapse-btn"]')
+  chatCollapser.click()
+  setTimeout(function() {
+    chatCollapser.click()
+  }, 500);
+}
+
+const joinChatRoom = () => {
+  // TODO find better way to join chat room, we should be able to
+  // hook directly into Twitch's callback
+  openAndCloseNativeChatContainer()
+}
+
+const isInChatRoom = () => {
+  // TODO find better way to check, we could already be in the chat room 
+  // even though the native chat is closed
+  rightColumnCollapsed = document.querySelector('.right-column--collapsed')
+  return !rightColumnCollapsed
+}
+
+module.exports = {
+  joinChatRoom,
+  isInChatRoom,
+}

--- a/src/current_page.js
+++ b/src/current_page.js
@@ -4,6 +4,14 @@ const forcedVOD = _ => {
   return (force_vod_param || window._TCO.currentGlobalSettings.forceVod) === 'true'
 }
 
+const getVODId = () => {
+  return (window.location.href.match(/\.tv\/videos\/([0-9]+)/) || [])[1]
+}
+
+const isRealVOD = () => {
+  return Boolean(getVODId())
+}
+
 const streamFromUrl = url => {
   if (url.match(/clips\.twitch\.tv/))
     return
@@ -15,9 +23,9 @@ const streamFromUrl = url => {
 const getCurrentStream = _ => streamFromUrl(window.location.href)
 
 const getCurrentVOD = _ => {
-  const vod = (window.location.href.match(/\.tv\/videos\/([0-9]+)/) || [])[1]
-  if (vod)
-    return vod
+  const vod_id = getVODId()
+  if (vod_id)
+    return vod_id
   if (forcedVOD())
     return streamFromUrl(window.location.href)
   return ''
@@ -41,6 +49,7 @@ const inVOD = _ => !!getCurrentVOD()
 
 module.exports = {
   inVOD,
+  isRealVOD,
   getCurrentStream,
   getCurrentVOD,
   getStreamFromVOD,

--- a/src/current_page.js
+++ b/src/current_page.js
@@ -47,11 +47,25 @@ const getStreamFromVOD = _ => {
 
 const inVOD = _ => !!getCurrentVOD()
 
+const isRightColumnClosed = () => {
+  return Boolean(document.querySelector('.right-column--collapsed'))
+}
+
+const openAndCloseRightColumn = () => {
+  rightColumnToggle = document.querySelector('[data-a-target="right-column__toggle-collapse-btn"]')
+  rightColumnToggle.click()
+  setTimeout(function() {
+    rightColumnToggle.click()
+  }, 500);
+}
+
 module.exports = {
   inVOD,
   isRealVOD,
   getCurrentStream,
   getCurrentVOD,
   getStreamFromVOD,
-  forcedVOD
+  forcedVOD,
+  isRightColumnClosed,
+  openAndCloseRightColumn,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -32,9 +32,7 @@ const init = async currentStream => {
   setupAutoClaimManager()
   
   const initialSetup = _ => {
-    const rightColumnCollapsed = document.querySelector('.right-column--collapsed'),
-          chatCollapser = document.querySelector('[data-a-target="right-column__toggle-collapse-btn"]'),
-          appendToParent = document.querySelector('.video-player__overlay')
+    const appendToParent = document.querySelector('.video-player__overlay')
     chatContainer = createChatContainer()
     appendTo = document.createElement('div')
     iframe = createIframe(_ => {
@@ -47,8 +45,6 @@ const init = async currentStream => {
 
       attachBaseStyle(iframe.contentDocument.body)
       iframe.style = ''
-      if (rightColumnCollapsed)
-        chatCollapser.click()
       removeClass(chatContainer, 'loading')
       const html = document.querySelector('html'),
             iframeHtml = iframe.contentDocument.querySelector('html'),
@@ -60,9 +56,6 @@ const init = async currentStream => {
           removeClass(iframeHtml, darkThemeClass)
       })
     })
-          
-    if (rightColumnCollapsed)
-      chatCollapser.click()
     
     chatContainer.addEventListener('mouseenter', _ => {
       const chatList = iframe.contentDocument.body.querySelector('.chat-list--default')

--- a/src/vod.js
+++ b/src/vod.js
@@ -1,5 +1,6 @@
 require('./tco')
 const { addClass, removeClass } = require('./class_utils')
+const { isInChatRoom, joinChatRoom } = require('./chat_room')
 const createChatContainer = require('./chat_container')
 const createToggle = require('./toggle')
 const { attachBaseStyle, STYLE_ATTRS, applyBackground, applyFont, applyToggles, settingsToStyle, styleToSettings } = require('./frame_style')
@@ -7,7 +8,7 @@ const { whenElementLoaded, whenUrlChanged } = require('./observer')
 const { getSettings, setSettings, getGlobalSettings } = require('./settings')
 const makeDraggable = require('./draggable')
 const makeResizable = require('./resizable')
-const { getStreamFromVOD, getCurrentVOD, forcedVOD } = require('./current_page')
+const { getStreamFromVOD, getCurrentVOD, isRealVOD } = require('./current_page')
 const setupAutoClaimManager = require('./claim_points')
 
 const enable = _ => addClass(document.body, 'anu-chat-overlay-active')
@@ -54,6 +55,10 @@ const init = async currentVOD => {
     appendTo = document.createElement('div')
 
     chatContainer = createChatContainer()
+
+    if (!isRealVOD() && !isInChatRoom())
+      joinChatRoom()
+    
     removeClass(chatContainer, 'loading')
 
     attachTo(chatElement, chatContainer)


### PR DESCRIPTION
## Context


Table below shows when ATCO tries to join the chat room by opening and closing the chat sidebar:
|    | iframe chat | Native chat |
| ------------- | ------------- | ------------- |
| Stream  | Yes  | No |
| VOD  | No  | No |

However, except if I'm missing something, the only time we need to do this is if we are using the native chat during a stream as VODs don't require joining a chat room and the iframe chat joins the chat room automatically.

## Changes
New behavior:
|    | iframe chat | Native chat |
| ------------- | ------------- | ------------- |
| Stream  | No  | Yes |
| VOD  | No  | No |

This should improve the experience for both use-cases impacted.


The only risk introduced by this PR should be for the use-case `Stream` + `iframe chat` if I somehow missed another reason for opening/closing the chat sidebar apart from trying to join the chat room.
