### PR TITLE
feat: Add option to auto close Twitch's chat column

### DIFF
--- a/src/current_page.js
+++ b/src/current_page.js
@@ -51,11 +51,21 @@ const isRightColumnClosed = () => {
   return Boolean(document.querySelector('.right-column--collapsed'))
 }
 
+// Hacky way to prevent double toggling when autoCloseRightColumn is true
+let isTogglingRightColumn = false;
+
+const toggleRightColumn = () => {
+  rightColumnToggle = document.querySelector('[data-a-target="right-column__toggle-collapse-btn"]')
+  rightColumnToggle.click()
+}
+
 const openAndCloseRightColumn = () => {
+  isTogglingRightColumn = true;
   rightColumnToggle = document.querySelector('[data-a-target="right-column__toggle-collapse-btn"]')
   rightColumnToggle.click()
   setTimeout(function() {
     rightColumnToggle.click()
+    isTogglingRightColumn = false;
   }, 500);
 }
 
@@ -67,5 +77,7 @@ module.exports = {
   getStreamFromVOD,
   forcedVOD,
   isRightColumnClosed,
+  isTogglingRightColumn: () => isTogglingRightColumn,
+  toggleRightColumn,
   openAndCloseRightColumn,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const { whenElementLoaded, whenClassToggled, whenUrlChanged } = require('./obser
 const { getSettings, setSettings, getGlobalSettings } = require('./settings')
 const makeDraggable = require('./draggable')
 const makeResizable = require('./resizable')
-const { inVOD, getCurrentStream } = require('./current_page')
+const { inVOD, getCurrentStream, isTogglingRightColumn, isRightColumnClosed, toggleRightColumn } = require('./current_page')
 const setupAutoClaimManager = require('./claim_points')
 
 const enable = _ => addClass(document.body, 'anu-chat-overlay-active')
@@ -74,10 +74,14 @@ const init = async currentStream => {
     if (!chatContainer)
       initialSetup()
     enabled = !enabled
-    if (enabled)
+    if (enabled) {
       enable()
-    else
+      if (!isTogglingRightColumn() && window._TCO.currentGlobalSettings.autoCloseRightColumn === 'true' && !isRightColumnClosed()) {
+        toggleRightColumn()
+      }
+    } else {
       disable()
+    }
   }
   document.querySelector('.video-player__overlay .player-controls__right-control-group').prepend(toggle)
 

--- a/src/options.html
+++ b/src/options.html
@@ -1,14 +1,24 @@
 <!DOCTYPE html>
 <html>
-<head><title>Global Settings</title></head>
+
+<head>
+  <title>Global Settings</title>
+</head>
+
 <body style="padding: 20px; margin: auto; font-size: 100%;">
   <label>
     <input type="checkbox" id="force_vod">
     <span>Avoid iframes (?force_vod=true by default)</span>
-    <small style="display: block; margin-top: 5px;">Checking this box should improve performance and fix issues related to third party emotes</small>
+    <small style="display: block; margin-top: 5px;">Checking this box should improve performance and fix issues related
+      to third party emotes</small>
+  </label>
+  <label style="margin-top: 10px;">
+    <input type="checkbox" id="auto_close_right_column">
+    <span>Automaticaly close right column when opening chat overlay</span>
   </label>
   <div style="margin-top: 25px;">You will need to reload existing Twitch tabs to apply new settings</div>
   <div id="DEBUG" style="display: none"></div>
   <script src="options.js"></script>
 </body>
+
 </html>

--- a/src/options.js
+++ b/src/options.js
@@ -8,8 +8,15 @@ const init = async _ => {
   force_vod_checkbox.addEventListener('change', e => {
     setGlobalSettings('forceVod', e.target.checked ? 'true' : 'false')
   })
-
   force_vod_checkbox.checked = window._TCO.currentGlobalSettings.forceVod === 'true'
+
+  const auto_close_chat_checkbox = document.querySelector('#auto_close_right_column')
+  auto_close_chat_checkbox.addEventListener('change', e => {
+    setGlobalSettings('autoCloseRightColumn', e.target.checked ? 'true' : 'false')
+  })
+  auto_close_chat_checkbox.checked = window._TCO.currentGlobalSettings.autoCloseRightColumn === 'true'
+
+
 }
 
 document.addEventListener('DOMContentLoaded', init)

--- a/src/settings.js
+++ b/src/settings.js
@@ -29,7 +29,8 @@ const DEFAULT_SETTINGS = {
 }
 
 const DEFAULT_GLOBAL_SETTINGS = {
-  forceVod: 'false'
+  forceVod: 'false',
+  autoCloseRightColumn: 'false'
 }
 
 const setSettings = (k, v) => {

--- a/src/vod.js
+++ b/src/vod.js
@@ -8,7 +8,7 @@ const { whenElementLoaded, whenUrlChanged } = require('./observer')
 const { getSettings, setSettings, getGlobalSettings } = require('./settings')
 const makeDraggable = require('./draggable')
 const makeResizable = require('./resizable')
-const { getStreamFromVOD, getCurrentVOD, isRealVOD } = require('./current_page')
+const { getStreamFromVOD, getCurrentVOD, isRealVOD, isRightColumnClosed, toggleRightColumn, isTogglingRightColumn } = require('./current_page')
 const setupAutoClaimManager = require('./claim_points')
 
 const enable = _ => addClass(document.body, 'anu-chat-overlay-active')
@@ -82,10 +82,14 @@ const init = async currentVOD => {
     if (!chatContainer)
       initialSetup()
     enabled = !enabled
-    if (enabled)
-      enable()
-    else
+    if (enabled) {
+      enable();
+      if (!isTogglingRightColumn() && window._TCO.currentGlobalSettings.autoCloseRightColumn === 'true' && !isRightColumnClosed()) {
+        toggleRightColumn()
+      }
+    } else {
       disable()
+    }
     attachTo(chatElement, enabled ? chatContainer : initialParent)
   }
   document.querySelector('.video-player__overlay .player-controls__right-control-group').prepend(toggle)


### PR DESCRIPTION
## Context 
In my opinion, users often wish to close Twitch's chat when they activate Anu's chat overlay. This PR aims at giving them the option to do so.

## Changes
- Add logic to close the right column when ATCO is initialized (if it was open at that moment and not already being toggled by ATCO)
- Add option in global settings to make the feature optional

This is not the cleanest implementation but it is functional (I have been using it for the past month without issue)
