### PR TITLE
Fix scrolling issue in settings menu for Chromium-based browsers

### DIFF
--- a/src/settings_panel.js
+++ b/src/settings_panel.js
@@ -1,5 +1,5 @@
 const MicroModal = require('micromodal').default
-const SimpleBar = require('simplebar').default
+// const SimpleBar = require('simplebar').default // Removed to fix scrolling issue in Chromium
 const { peepoPainter } = require('./images')
 const { applyBackground, applyFont, applyToggles, settingsToStyle, styleToSettings, STYLE_ATTRS, SETTINGS_TO_STYLE_FN } = require('./frame_style')
 const { setSettings, DEFAULT_SETTINGS, ISSUES_TRACKER_LINK } = require('./settings')
@@ -379,13 +379,14 @@ module.exports = _ => {
   }
 
   document.querySelector('.video-player__overlay').append(panel)
-  if (window.chrome && chrome.runtime && chrome.runtime.id) {
-    const scroller = panel.querySelector('.settings-scroller')
-    new SimpleBar(scroller, {
-      autoHide: false
-    })
-    addClass(scroller, 'overflow-y-hidden')
-  }
+  // Removed SimpleBar implementation for Chromium browsers to fix scrolling issue
+  // if (window.chrome && chrome.runtime && chrome.runtime.id) {
+  //   const scroller = panel.querySelector('.settings-scroller')
+  //   new SimpleBar(scroller, {
+  //     autoHide: false
+  //   })
+  //   addClass(scroller, 'overflow-y-hidden')
+  // }
 
   const aboutPanel = createAboutPanel()
   panel.querySelector('.about-us-icon').onclick = e => {


### PR DESCRIPTION
## Problem
The settings menu was not scrollable in Chromium-based browsers (Chrome, Edge, Brave), preventing users from accessing settings beyond the first few options.

## Solution
Removed the SimpleBar implementation that was specifically targeting Chromium browsers. The extension now uses the native scrollbar in all browsers, providing consistent and reliable behavior across all platforms.

## Changes
- Commented out SimpleBar import in `settings_panel.js`
- Removed the conditional code that applied SimpleBar to Chromium browsers
- All browsers now use the native scrollbar implementation

## Testing
- ✅ Firefox: Scrolling continues to work (was already using native scrollbar)
- ✅ Chrome: Scrolling now works correctly
- ✅ Edge: Scrolling now works correctly  
- ✅ All settings options are now accessible in all browsers

## Impact
This fix restores full functionality of the settings menu for all Chromium browser users, allowing them to access and configure all available settings options.
